### PR TITLE
[docker] Fix conda installation

### DIFF
--- a/docker/Dockerfile.pytorch
+++ b/docker/Dockerfile.pytorch
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
      rm -rf /var/lib/apt/lists/*
 
 # Install miniconda, pytorch and other useful python libraries
-RUN curl -o ~/miniconda.sh -O  https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh  && \
+RUN curl --location --output ~/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda2-latest-Linux-x86_64.sh && \
 chmod +x ~/miniconda.sh && \
 ~/miniconda.sh -b -p /opt/conda && \
 rm ~/miniconda.sh && \


### PR DESCRIPTION
The conda installation was broken because the continuum URL redirects to https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh, which wasn't being followed because curl was missing the -L (--location) flag.

This fixes the URL and ensures that future changes don't break the Dockerfile